### PR TITLE
implement cb default port

### DIFF
--- a/couchbase/client.go
+++ b/couchbase/client.go
@@ -193,10 +193,11 @@ func (s *client) connect(bucketName string, connectionBufferSize uint, connectio
 }
 
 func resolveHostsAsHTTP(hosts []string) []string {
-	if len(hosts) == 1 {
-		parsedConnStr, err := connstr.Parse(hosts[0])
+	var httpHosts []string
+	for _, host := range hosts {
+		parsedConnStr, err := connstr.Parse(host)
 		if err != nil {
-			err := errors.New(hosts[0] + " " + err.Error())
+			err := errors.New(host + " " + err.Error())
 			logger.Log.Error("error while parsing connection string, err: %v", err)
 			panic(err)
 		}
@@ -208,15 +209,12 @@ func resolveHostsAsHTTP(hosts []string) []string {
 			panic(err)
 		}
 
-		var httpHosts []string
 		for _, specHost := range out.HttpHosts {
 			httpHosts = append(httpHosts, fmt.Sprintf("%s:%d", specHost.Host, specHost.Port))
 		}
-
-		return httpHosts
 	}
 
-	return hosts
+	return httpHosts
 }
 
 func (s *client) Connect() error {

--- a/couchbase/client_test.go
+++ b/couchbase/client_test.go
@@ -1,0 +1,65 @@
+package couchbase
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClient_ResolveHttpAddress(t *testing.T) {
+
+	t.Run("single host with port", func(t *testing.T) {
+		// Arrange
+		givenHosts := []string{"localhost:8091"}
+		expectedHosts := []string{"localhost:8091"}
+
+		// Act
+		resolvedHosts := resolveHostsAsHTTP(givenHosts)
+
+		// Assert
+		if !reflect.DeepEqual(resolvedHosts, expectedHosts) {
+			t.Errorf("Unexpected result. got %v want %v", resolvedHosts, expectedHosts)
+		}
+	})
+
+	t.Run("single host without port", func(t *testing.T) {
+		// Arrange
+		givenHosts := []string{"localhost"}
+		expectedHosts := []string{"localhost:8091"}
+
+		// Act
+		resolvedHosts := resolveHostsAsHTTP(givenHosts)
+
+		// Assert
+		if !reflect.DeepEqual(resolvedHosts, expectedHosts) {
+			t.Errorf("Unexpected result. got %v want %v", resolvedHosts, expectedHosts)
+		}
+	})
+
+	t.Run("multi host with port", func(t *testing.T) {
+		// Arrange
+		givenHosts := []string{"localhost:8091", "localhost_2:8091", "localhost_3:8091"}
+		expectedHosts := []string{"localhost:8091", "localhost_2:8091", "localhost_3:8091"}
+
+		// Act
+		resolvedHosts := resolveHostsAsHTTP(givenHosts)
+
+		// Assert
+		if !reflect.DeepEqual(resolvedHosts, expectedHosts) {
+			t.Errorf("Unexpected result. got %v want %v", resolvedHosts, expectedHosts)
+		}
+	})
+
+	t.Run("multi host without port", func(t *testing.T) {
+		// Arrange
+		givenHosts := []string{"localhost", "localhost_2", "localhost_3"}
+		expectedHosts := []string{"localhost:8091", "localhost_2:8091", "localhost_3:8091"}
+
+		// Act
+		resolvedHosts := resolveHostsAsHTTP(givenHosts)
+
+		// Assert
+		if !reflect.DeepEqual(resolvedHosts, expectedHosts) {
+			t.Errorf("Unexpected result. got %v want %v", resolvedHosts, expectedHosts)
+		}
+	})
+}


### PR DESCRIPTION
Resolves #95 

When more than one couchbase data node IP is given, an error is received when connecting because the default port is not set.

The default port set as 8091.