### PR TITLE
feat: Tracing implementation

### DIFF
--- a/couchbase/observer.go
+++ b/couchbase/observer.go
@@ -2,9 +2,10 @@ package couchbase
 
 import (
 	"context"
-	"github.com/Trendyol/go-dcp/tracing"
 	"reflect"
 	"time"
+
+	"github.com/Trendyol/go-dcp/tracing"
 
 	"github.com/asaskevich/EventBus"
 

--- a/dcp.go
+++ b/dcp.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/Trendyol/go-dcp/tracing"
 	"os"
 	"os/signal"
 	"reflect"
 	"regexp"
 	"strings"
 	"syscall"
+
+	"github.com/Trendyol/go-dcp/tracing"
 
 	"github.com/Trendyol/go-dcp/metric"
 

--- a/dcp.go
+++ b/dcp.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/Trendyol/go-dcp/tracing"
 	"os"
 	"os/signal"
 	"reflect"
@@ -113,9 +114,12 @@ func (s *dcp) Start() {
 
 	s.vBucketDiscovery = stream.NewVBucketDiscovery(s.client, s.config, vBuckets, s.bus)
 
+	tc := tracing.NewTracerComponent()
+
 	s.stream = stream.NewStream(
 		s.client, s.metadata, s.config, s.version, s.bucketInfo, s.vBucketDiscovery,
 		s.listener, s.client.GetCollectionIDs(s.config.ScopeName, s.config.CollectionNames), s.stopCh, s.bus, s.eventHandler,
+		tc,
 	)
 
 	if s.config.LeaderElection.Enabled {

--- a/dcp_test.go
+++ b/dcp_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Trendyol/go-dcp/config"
 
 	"github.com/Trendyol/go-dcp/couchbase"
-	// _ "github.com/emrygun/go-dcp-tracing-otel"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 

--- a/example/grafana/go.mod
+++ b/example/grafana/go.mod
@@ -83,4 +83,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-

--- a/example/grafana/go.mod
+++ b/example/grafana/go.mod
@@ -83,3 +83,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+

--- a/models/listeners.go
+++ b/models/listeners.go
@@ -1,13 +1,19 @@
 package models
 
+import (
+	"github.com/Trendyol/go-dcp/tracing"
+)
+
 type ListenerContext struct {
-	Commit func()
-	Event  interface{}
-	Ack    func()
+	Commit                  func()
+	Event                   interface{}
+	Ack                     func()
+	ListenerTracerComponent tracing.ListenerTracerComponent
 }
 
 type ListenerArgs struct {
-	Event interface{}
+	Event        interface{}
+	TraceContext tracing.RequestSpanContext
 }
 
 type DcpStreamEndContext struct {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"errors"
 	"fmt"
+	"github.com/Trendyol/go-dcp/tracing"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -54,20 +55,21 @@ type stream struct {
 	vBucketDiscovery             VBucketDiscovery
 	bus                          EventBus.Bus
 	eventHandler                 models.EventHandler
-	bucketInfo                   *couchbase.BucketInfo
-	observers                    *wrapper.ConcurrentSwissMap[uint16, couchbase.Observer]
+	config                       *config.Dcp
+	metric                       *Metric
 	rebalanceTimer               *time.Timer
 	vbIDRange                    *models.VbIDRange
 	dirtyOffsets                 *wrapper.ConcurrentSwissMap[uint16, bool]
 	stopCh                       chan struct{}
 	listener                     models.Listener
-	config                       *config.Dcp
+	bucketInfo                   *couchbase.BucketInfo
 	finishStreamWithEndEventCh   chan struct{}
 	finishStreamWithCloseCh      chan struct{}
 	offsets                      *wrapper.ConcurrentSwissMap[uint16, *models.Offset]
-	metric                       *Metric
+	observers                    *wrapper.ConcurrentSwissMap[uint16, couchbase.Observer]
 	collectionIDs                map[uint32]string
 	streamEndNotSupportedData    *streamEndNotSupportedData
+	tracerComponent              *tracing.TracerComponent
 	rebalanceLock                sync.Mutex
 	activeStreams                atomic.Int32
 	streamFinishedWithCloseCh    bool
@@ -105,7 +107,7 @@ func (s *stream) setOffset(vbID uint16, offset *models.Offset, dirty bool) {
 	}
 }
 
-func (s *stream) waitAndForward(payload interface{}, offset *models.Offset, vbID uint16, eventTime time.Time) {
+func (s *stream) waitAndForward(payload interface{}, spanCtx tracing.RequestSpanContext, offset *models.Offset, vbID uint16, eventTime time.Time) {
 	if helpers.IsMetadata(payload) {
 		s.setOffset(vbID, offset, false)
 		return
@@ -120,6 +122,7 @@ func (s *stream) waitAndForward(payload interface{}, offset *models.Offset, vbID
 			s.setOffset(vbID, offset, true)
 			s.anyDirtyOffset = true
 		},
+		ListenerTracerComponent: s.tracerComponent.NewListenerTracerComponent(spanCtx),
 	}
 
 	start := time.Now()
@@ -132,11 +135,11 @@ func (s *stream) waitAndForward(payload interface{}, offset *models.Offset, vbID
 func (s *stream) listen(args models.ListenerArgs) {
 	switch v := args.Event.(type) {
 	case models.DcpMutation:
-		s.waitAndForward(v, v.Offset, v.VbID, v.EventTime)
+		s.waitAndForward(v, args.TraceContext, v.Offset, v.VbID, v.EventTime)
 	case models.DcpDeletion:
-		s.waitAndForward(v, v.Offset, v.VbID, v.EventTime)
+		s.waitAndForward(v, args.TraceContext, v.Offset, v.VbID, v.EventTime)
 	case models.DcpExpiration:
-		s.waitAndForward(v, v.Offset, v.VbID, v.EventTime)
+		s.waitAndForward(v, args.TraceContext, v.Offset, v.VbID, v.EventTime)
 	case models.DcpSeqNoAdvanced:
 		s.setOffset(v.VbID, v.Offset, true)
 	case models.DcpCollectionCreation:
@@ -240,7 +243,7 @@ func (s *stream) Open() {
 	for _, vbID := range vbIDs {
 		s.observers.Store(
 			vbID,
-			couchbase.NewObserver(s.config, vbID, s.listen, s.listenEnd, s.collectionIDs, s.bus),
+			couchbase.NewObserver(s.config, vbID, s.listen, s.listenEnd, s.collectionIDs, s.bus, s.tracerComponent),
 		)
 	}
 
@@ -457,6 +460,7 @@ func NewStream(client couchbase.Client,
 	stopCh chan struct{},
 	bus EventBus.Bus,
 	eventHandler models.EventHandler,
+	tc *tracing.TracerComponent,
 ) Stream {
 	stream := &stream{
 		client:                     client,
@@ -472,6 +476,7 @@ func NewStream(client couchbase.Client,
 		bus:                        bus,
 		eventHandler:               eventHandler,
 		metric:                     &Metric{},
+		tracerComponent:            tc,
 	}
 
 	if version.Lower(couchbase.SrvVer550) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -3,10 +3,11 @@ package stream
 import (
 	"errors"
 	"fmt"
-	"github.com/Trendyol/go-dcp/tracing"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Trendyol/go-dcp/tracing"
 
 	"github.com/Trendyol/go-dcp/membership"
 
@@ -107,7 +108,13 @@ func (s *stream) setOffset(vbID uint16, offset *models.Offset, dirty bool) {
 	}
 }
 
-func (s *stream) waitAndForward(payload interface{}, spanCtx tracing.RequestSpanContext, offset *models.Offset, vbID uint16, eventTime time.Time) {
+func (s *stream) waitAndForward(
+	payload interface{},
+	spanCtx tracing.RequestSpanContext,
+	offset *models.Offset,
+	vbID uint16,
+	eventTime time.Time,
+) {
 	if helpers.IsMetadata(payload) {
 		s.setOffset(vbID, offset, false)
 		return

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -6,11 +6,7 @@ import (
 	"time"
 )
 
-// TracerContext
-// ---------------------------------------------------------------------------------------------------------------------
-var (
-	tracerCtx = tracerContext{tracer: &NoopTracer{}}
-)
+var tracerCtx = tracerContext{tracer: &NoopTracer{}}
 
 type tracerContext struct {
 	tracer RequestTracer
@@ -24,8 +20,6 @@ func RegisterRequestTracer(requestTracer RequestTracer) error {
 
 	return fmt.Errorf("RequestTracer already registered %s", requestTracer)
 }
-
-// ---------------------------------------------------------------------------------------------------------------------
 
 type RequestTracer interface {
 	RequestSpan(parentContext RequestSpanContext, operationName string) RequestSpan
@@ -44,8 +38,6 @@ type RequestSpan interface {
 	SetAttribute(key string, value interface{})
 }
 
-// noop tracer
-// ---------------------------------------------------------------------------------------------------------------------
 type noopSpan struct{}
 
 var (
@@ -78,9 +70,6 @@ func (span noopSpan) SetAttribute(key string, value interface{}) {
 func (span noopSpan) AddEvent(key string, timestamp time.Time) {
 }
 
-// Trace
-// ---------------------------------------------------------------------------------------------------------------------
-
 type Trace struct {
 	rsc RequestSpanContext
 	rs  RequestSpan
@@ -98,8 +87,6 @@ func (t *Trace) RootContext() RequestSpanContext {
 	}
 	return t.rsc
 }
-
-// ---------------------------------------------------------------------------------------------------------------------
 
 type ObserverLabels struct {
 	collectionIDs map[uint32]string
@@ -206,7 +193,6 @@ func (tc *listenerTracerComponent) CreateListenerTrace(
 	}
 }
 
-// ---------------------------------------------------------------------------------------------------------------------
 type opTracer struct {
 	parentContext RequestSpanContext
 	opSpan        RequestSpan
@@ -245,7 +231,6 @@ func (tracer *listenerTracer) RootContext() RequestSpanContext {
 	return tracer.parentContext
 }
 
-// ---------------------------------------------------------------------------------------------------------------------
 type opTelemetryHandler struct {
 	start             time.Time
 	tracer            *opTracer

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -54,8 +54,7 @@ var (
 )
 
 //nolint:unused
-type NoopTracer struct {
-}
+type NoopTracer struct{}
 
 // RequestSpan creates a new RequestSpan.
 func (tracer *NoopTracer) RequestSpan(parentContext RequestSpanContext, operationName string) RequestSpan {
@@ -104,11 +103,11 @@ func (t *Trace) RootContext() RequestSpanContext {
 
 type ObserverLabels struct {
 	collectionIDs map[uint32]string
-	vbId          uint16
+	vbID          uint16
 }
 
-func NewObserverLabels(vbId uint16, collectionIDs map[uint32]string) *ObserverLabels {
-	return &ObserverLabels{vbId: vbId, collectionIDs: collectionIDs}
+func NewObserverLabels(vbID uint16, collectionIDs map[uint32]string) *ObserverLabels {
+	return &ObserverLabels{vbID: vbID, collectionIDs: collectionIDs}
 }
 
 type TracerComponent struct {
@@ -146,7 +145,7 @@ func (tc *TracerComponent) createOpTrace(
 	opSpan.SetAttribute("op.attributes", parentContext.Value)
 
 	// Append labels
-	opSpan.SetAttribute("vb_id", observerLabels.vbId)
+	opSpan.SetAttribute("vb_id", observerLabels.vbID)
 	opSpan.SetAttribute("collection_ids", observerLabels.collectionIDs)
 
 	return &opTracer{
@@ -172,7 +171,10 @@ func (tc *TracerComponent) NewListenerTracerComponent(opTracerContext RequestSpa
 	}
 }
 
-func (tc *listenerTracerComponent) InitializeListenerTrace(operationName string, attributes map[string]interface{}) *listenerTracer {
+func (tc *listenerTracerComponent) InitializeListenerTrace(
+	operationName string,
+	attributes map[string]interface{},
+) *listenerTracer {
 	listenerSpan := tc.tracerComponent.tracer.RequestSpan(tc.opContext, operationName)
 
 	// Append labels
@@ -186,7 +188,11 @@ func (tc *listenerTracerComponent) InitializeListenerTrace(operationName string,
 	}
 }
 
-func (tc *listenerTracerComponent) CreateListenerTrace(trace *listenerTracer, operationName string, attributes map[string]interface{}) *listenerTracer {
+func (tc *listenerTracerComponent) CreateListenerTrace(
+	trace *listenerTracer,
+	operationName string,
+	attributes map[string]interface{},
+) *listenerTracer {
 	listenerSpan := tc.tracerComponent.tracer.RequestSpan(trace.parentContext, operationName)
 
 	// Append labels

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,265 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// TracerContext
+// ---------------------------------------------------------------------------------------------------------------------
+var (
+	tracerCtx = tracerContext{tracer: &NoopTracer{}}
+)
+
+type tracerContext struct {
+	tracer RequestTracer
+}
+
+func RegisterRequestTracer(requestTracer RequestTracer) error {
+	if _, ok := tracerCtx.tracer.(*NoopTracer); ok {
+		tracerCtx.tracer = requestTracer
+		return nil
+	}
+
+	return fmt.Errorf("RequestTracer already registered %s", requestTracer)
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+type RequestTracer interface {
+	RequestSpan(parentContext RequestSpanContext, operationName string) RequestSpan
+}
+
+type RequestSpanContext struct {
+	RefCtx context.Context
+	Value  interface{}
+}
+
+type RequestSpan interface {
+	End()
+	Context() RequestSpanContext
+	AddEvent(name string, timestamp time.Time)
+
+	SetAttribute(key string, value interface{})
+}
+
+// noop tracer
+// ---------------------------------------------------------------------------------------------------------------------
+type noopSpan struct{}
+
+var (
+	defaultNoopSpanContext = RequestSpanContext{RefCtx: context.TODO(), Value: nil}
+	defaultNoopSpan        = noopSpan{}
+)
+
+//nolint:unused
+type NoopTracer struct {
+}
+
+// RequestSpan creates a new RequestSpan.
+func (tracer *NoopTracer) RequestSpan(parentContext RequestSpanContext, operationName string) RequestSpan {
+	return defaultNoopSpan
+}
+
+// End completes the span.
+func (span noopSpan) End() {
+}
+
+// Context returns the RequestSpanContext for this span.
+func (span noopSpan) Context() RequestSpanContext {
+	return defaultNoopSpanContext
+}
+
+// SetAttribute adds an attribute to this span.
+func (span noopSpan) SetAttribute(key string, value interface{}) {
+}
+
+// AddEvent adds an event to this span.
+func (span noopSpan) AddEvent(key string, timestamp time.Time) {
+}
+
+// Trace
+// ---------------------------------------------------------------------------------------------------------------------
+
+type Trace struct {
+	rsc RequestSpanContext
+	rs  RequestSpan
+}
+
+func (t *Trace) Finish() {
+	if t.rs != nil {
+		t.rs.End()
+	}
+}
+
+func (t *Trace) RootContext() RequestSpanContext {
+	if t.rs != nil {
+		return t.rs.Context()
+	}
+	return t.rsc
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+type ObserverLabels struct {
+	collectionIDs map[uint32]string
+	vbId          uint16
+}
+
+func NewObserverLabels(vbId uint16, collectionIDs map[uint32]string) *ObserverLabels {
+	return &ObserverLabels{vbId: vbId, collectionIDs: collectionIDs}
+}
+
+type TracerComponent struct {
+	tracer RequestTracer
+}
+
+func NewTracerComponent() *TracerComponent {
+	requestTracer := tracerCtx.tracer
+	return &TracerComponent{
+		tracer: requestTracer,
+	}
+}
+
+func (tc *TracerComponent) StartOpTelemeteryHandler(
+	service string,
+	operation string,
+	traceContext RequestSpanContext,
+	observerLabels *ObserverLabels,
+) *opTelemetryHandler {
+	return &opTelemetryHandler{
+		tracer:            tc.createOpTrace(operation, traceContext, observerLabels),
+		service:           service,
+		operation:         operation,
+		start:             time.Now(),
+		metricsCompleteFn: tc.ResponseValueRecord,
+	}
+}
+
+func (tc *TracerComponent) createOpTrace(
+	operationName string,
+	parentContext RequestSpanContext,
+	observerLabels *ObserverLabels,
+) *opTracer {
+	opSpan := tc.tracer.RequestSpan(parentContext, operationName)
+	opSpan.SetAttribute("op.attributes", parentContext.Value)
+
+	// Append labels
+	opSpan.SetAttribute("vb_id", observerLabels.vbId)
+	opSpan.SetAttribute("collection_ids", observerLabels.collectionIDs)
+
+	return &opTracer{
+		parentContext: parentContext,
+		opSpan:        opSpan,
+	}
+}
+
+type ListenerTracerComponent interface {
+	InitializeListenerTrace(operationName string, attributes map[string]interface{}) *listenerTracer
+	CreateListenerTrace(trace *listenerTracer, operationName string, attributes map[string]interface{}) *listenerTracer
+}
+
+type listenerTracerComponent struct {
+	tracerComponent *TracerComponent
+	opContext       RequestSpanContext
+}
+
+func (tc *TracerComponent) NewListenerTracerComponent(opTracerContext RequestSpanContext) ListenerTracerComponent {
+	return &listenerTracerComponent{
+		tracerComponent: tc,
+		opContext:       opTracerContext,
+	}
+}
+
+func (tc *listenerTracerComponent) InitializeListenerTrace(operationName string, attributes map[string]interface{}) *listenerTracer {
+	listenerSpan := tc.tracerComponent.tracer.RequestSpan(tc.opContext, operationName)
+
+	// Append labels
+	for key, value := range attributes {
+		listenerSpan.SetAttribute(key, value)
+	}
+
+	return &listenerTracer{
+		parentContext: listenerSpan.Context(),
+		span:          listenerSpan,
+	}
+}
+
+func (tc *listenerTracerComponent) CreateListenerTrace(trace *listenerTracer, operationName string, attributes map[string]interface{}) *listenerTracer {
+	listenerSpan := tc.tracerComponent.tracer.RequestSpan(trace.parentContext, operationName)
+
+	// Append labels
+	for key, value := range attributes {
+		listenerSpan.SetAttribute(key, value)
+	}
+
+	return &listenerTracer{
+		parentContext: listenerSpan.Context(),
+		span:          listenerSpan,
+	}
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+type opTracer struct {
+	parentContext RequestSpanContext
+	opSpan        RequestSpan
+}
+
+func (tracer *opTracer) Finish() {
+	if tracer.opSpan != nil {
+		tracer.opSpan.End()
+	}
+}
+
+func (tracer *opTracer) RootContext() RequestSpanContext {
+	if tracer.opSpan != nil {
+		return tracer.opSpan.Context()
+	}
+
+	return tracer.parentContext
+}
+
+type listenerTracer struct {
+	parentContext RequestSpanContext
+	span          RequestSpan
+}
+
+func (tracer *listenerTracer) Finish() {
+	if tracer.span != nil {
+		tracer.span.End()
+	}
+}
+
+func (tracer *listenerTracer) RootContext() RequestSpanContext {
+	if tracer.span != nil {
+		return tracer.span.Context()
+	}
+
+	return tracer.parentContext
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+type opTelemetryHandler struct {
+	start             time.Time
+	tracer            *opTracer
+	metricsCompleteFn func(string, string, time.Time)
+	service           string
+	operation         string
+}
+
+func (oth *opTelemetryHandler) RootContext() RequestSpanContext {
+	return oth.tracer.RootContext()
+}
+
+func (oth *opTelemetryHandler) StartTime() time.Time {
+	return oth.start
+}
+
+func (oth *opTelemetryHandler) Finish() {
+	oth.tracer.Finish()
+	oth.metricsCompleteFn(oth.service, oth.operation, oth.start)
+}
+
+func (tc *TracerComponent) ResponseValueRecord(service, operation string, start time.Time) {
+}


### PR DESCRIPTION
# Tracing Implementation

## Motivation
Our goal is to enable go-dcp users to trace their internal operations and propagate those traces effectively. 

To achieve this, we aim to provide a generic API that could be implemented with various tracing solutions, such as OpenTelemetry, New Relic, and others. 

This approach ensures flexibility and compatibility, allowing users to adopt the tracing solution that best fits their requirements.

## Overall Architecture

### Main Components
- **RequestTracer:** Interface for creating and managing spans. Default implementation is NoopRequestTracer. Should be implemented by tracing vendor extensions.
- **RequestSpan:** Interface representing a span with methods to end it, add events, and set attributes. Default implementation is NoopRequestSpan. Should be implemented by tracing vendor extensions.
- **TracerComponent:** Struct that uses RequestTracer to create and manage spans. Provides internal operation tracing and labeling.
- **ListenerTracerComponent:** Interface for initializing and creating listener traces. Lets users to trace their operations through Listeners with contextfully. Parent context of the current operations are propogated to traces created by user.

### What Are We Going To Trace?
- DCP Events and handling contexts with their common labels.
- (Not In The Scope) Leader elections
- (Not In The Scope) Config watchers/changes, agents etc.

### Example Tracing
```
|-------------------------------- DCP Operation Span ------------------------------------|
|--|========== Listener Span ===========|================== Listener Span ===============|
                                        |================|
                                        |=====|
                                              |==========|
                                              |=====|
                                                    |====|
                                                         |==============================|
                                                         |=========|
                                                         |==============|
                                                                        |===============|

```
(`-` Internal Operation Traces)
(`=` Listener Traces)


As shown on example, context of internal operation traces are propogated into listener spans and consumers are creating their spans in terms of internal operation using `ListenerTracerComponent`.

## OpenTelemetry Tracer Implementation: `go-dcp-tracing-otel`
Check out `go-dcp-tracing-otel`: https://github.com/emrygun/go-dcp-tracing-otel

---

## Related `gocb/gocbcore` Tasks
- [GOCBC-264: Implemented OpenTracing tracing](https://review.couchbase.com/c/gocbcore/+/90168)
- [GOCBC-500: Remove references to opentracing](https://review.couchbase.com/c/gocbcore/+/111953)
- [GOCBC-656: Add support for tracing](https://review.couchbase.org/c/gocbcore/+/116729)
- [Reenable tracing in http based services](https://review.couchbase.org/c/gocbcore/+/125386/2)
- [Create a stats component](https://review.couchbase.org/c/gocbcore/+/125389/2)

---
* Implemented primitive tracing features
* Tidied up the project modules

Refs: #78