### PR TITLE
fix: correct cbgo_dcp_latency_ms_current metric type from Counter to Gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ In case you haven't configured a metric.path, the metrics will be exposed at the
 | cbgo_lag_current                     | The current lag on a specific vBucket                   | vbId: ID of the vBucket                  | Gauge      |
 | cbgo_total_lag_current               | The current total lag                                   | N/A                                      | Gauge      |
 | cbgo_process_latency_ms_current      | The latest process latency in milliseconds              | N/A                                      | Gauge      |
-| cbgo_dcp_latency_ms_current          | The latest consumed dcp message latency in milliseconds | N/A                                      | Counter    |
+| cbgo_dcp_latency_ms_current          | The latest consumed dcp message latency in milliseconds | N/A                                      | Gauge      |
 | cbgo_rebalance_current               | The number of total rebalance                           | N/A                                      | Counter    |
 | cbgo_active_stream_current           | The number of total active stream                       | N/A                                      | Gauge      |
 | cbgo_total_members_current           | The total number of members in the cluster              | N/A                                      | Gauge      |

--- a/metric/collector.go
+++ b/metric/collector.go
@@ -194,7 +194,7 @@ func (s *metricCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(
 		s.dcpLatency,
-		prometheus.CounterValue,
+		prometheus.GaugeValue,
 		float64(streamMetric.DcpLatency),
 		[]string{}...,
 	)
@@ -342,7 +342,7 @@ func NewMetricCollector(client couchbase.Client, stream stream.Stream, vBucketDi
 		),
 		processLatency: prometheus.NewDesc(
 			prometheus.BuildFQName(helpers.Name, "process_latency_ms", "current"),
-			"Average process latency ms",
+			"Latest process latency ms",
 			[]string{},
 			nil,
 		),


### PR DESCRIPTION
## What

`cbgo_dcp_latency_ms_current` was exported as `prometheus.CounterValue` in
`metric/collector.go`, but its underlying value is a **point-in-time latency
snapshot** that is overwritten on every DCP event — not a monotonically
increasing total.

## Why It Matters

Prometheus counters **must never decrease**. Because latency fluctuates
naturally (fast events produce small values, slow ones produce large values),
this metric regularly decreases between scrapes. This causes:

- Prometheus to emit stale-marker errors or silently drop decreasing counter samples
- `rate()` and `increase()` PromQL functions to return incorrect or zero results
- Grafana panels and alerts based on this metric to show misleading data

The inconsistency is easy to confirm by comparing the two latency metrics
side by side in `collector.go`:

```go
// processLatency — correctly exported as GaugeValue
ch <- prometheus.MustNewConstMetric(s.processLatency, prometheus.GaugeValue, ...)

// dcpLatency — incorrectly exported as CounterValue  ← this PR fixes it
ch <- prometheus.MustNewConstMetric(s.dcpLatency, prometheus.CounterValue, ...)