### PR TITLE
fix: reopen stream on any unexpected stream end error

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -204,12 +204,8 @@ func (s *stream) listenEnd(endContext models.DcpStreamEndContext) {
 		logger.Log.Debug("end stream vbID: %v", endContext.Event.VbID)
 	}
 
-	if !s.closeWithCancel && endContext.Err != nil &&
-		(errors.Is(endContext.Err, gocbcore.ErrSocketClosed) ||
-			errors.Is(endContext.Err, gocbcore.ErrDCPBackfillFailed) ||
-			errors.Is(endContext.Err, gocbcore.ErrDCPStreamStateChanged) ||
-			errors.Is(endContext.Err, gocbcore.ErrDCPStreamTooSlow) ||
-			errors.Is(endContext.Err, gocbcore.ErrDCPStreamDisconnected)) {
+	if !s.closeWithCancel && !s.balancing && endContext.Err != nil &&
+		!errors.Is(endContext.Err, gocbcore.ErrDCPStreamClosed) {
 		go s.reopenStream(endContext.Event.VbID)
 	} else {
 		activeStreams := s.activeStreams.Add(-1)


### PR DESCRIPTION
## Problem

In production we observe a subset of vBuckets silently stop being consumed: their DCP lag grows linearly for hours while the remaining vBuckets keep processing. The pod reports healthy, and the only remedy is a manual restart. This happens both on high-traffic buckets and on near-idle ones (1-2 vBuckets stuck), typically after rebalance/connection events.

## Root cause

`listenEnd` only reopens a vBucket stream when the stream end error matches a hardcoded allowlist of 5 errors (`ErrSocketClosed`, `ErrDCPBackfillFailed`, `ErrDCPStreamStateChanged`, `ErrDCPStreamTooSlow`, `ErrDCPStreamDisconnected`). A stream ending with **any other error** falls through to the else branch: `activeStreams` is decremented and the vBucket is abandoned — no retry, no recovery until restart.

## Change

Invert the allowlist into a denylist: reopen on any non-nil stream end error except `ErrDCPStreamClosed` (the deliberate-close signal from our own `CloseStream`). The reasoning: the *do-not-reopen* set is closed and well-defined (deliberate close, natural finite-stream end with `err == nil`), while the *reopen* set is open-ended and varies across gocbcore versions — enumerating it guarantees this bug class recurs.

The new `!s.balancing` guard also fixes a pre-existing race: an allowlisted error arriving during a rebalance close could trigger `reopenStream` while `offsets`/`observers` were being torn down, panicking in `openStream` ("vbID not found on offset map").

Failure-mode asymmetry favors this direction: a wrong reopen fails loudly (5 retries → panic → restart), while a wrong abandonment fails silently (unbounded lag). Rollback on reopen is already handled by `openStreamWithRollback`.

## Testing

`go build` / `go vet` clean, all unit tests pass.
