### PR TITLE
feat: report inactive dcp streams on /status endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -71,6 +71,17 @@ func (s *api) status(c *fiber.Ctx) error {
 		return err
 	}
 
+	if s.stream.IsOpen() {
+		offsets, _, _ := s.stream.GetOffsets()
+		expected := int32(offsets.Count())
+		if _, activeStreams := s.stream.GetMetric(); activeStreams < expected {
+			return fiber.NewError(
+				fiber.StatusServiceUnavailable,
+				fmt.Sprintf("only %d/%d dcp streams are active", activeStreams, expected),
+			)
+		}
+	}
+
 	return c.SendString("OK")
 }
 

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Trendyol/go-dcp/couchbase"
+	"github.com/Trendyol/go-dcp/models"
+	"github.com/Trendyol/go-dcp/stream"
+	"github.com/Trendyol/go-dcp/wrapper"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// fakeClient only implements Ping; the embedded interface satisfies the rest.
+type fakeClient struct {
+	couchbase.Client
+	pingErr error
+}
+
+func (c *fakeClient) Ping() (*models.PingResult, error) {
+	return &models.PingResult{}, c.pingErr
+}
+
+// fakeStream only implements what status() reads; the embedded interface
+// satisfies the rest.
+type fakeStream struct {
+	stream.Stream
+	open          bool
+	assignedVbIDs int
+	activeStreams int32
+}
+
+func (s *fakeStream) IsOpen() bool { return s.open }
+
+func (s *fakeStream) GetOffsets() (
+	*wrapper.ConcurrentSwissMap[uint16, *models.Offset],
+	*wrapper.ConcurrentSwissMap[uint16, bool],
+	bool,
+) {
+	offsets := wrapper.CreateConcurrentSwissMap[uint16, *models.Offset](uint64(s.assignedVbIDs))
+	for i := 0; i < s.assignedVbIDs; i++ {
+		offsets.Store(uint16(i), &models.Offset{})
+	}
+	return offsets, nil, false
+}
+
+func (s *fakeStream) GetMetric() (*stream.Metric, int32) {
+	return &stream.Metric{}, s.activeStreams
+}
+
+func TestStatus(t *testing.T) {
+	cases := []struct {
+		name          string
+		pingErr       error
+		open          bool
+		assignedVbIDs int
+		activeStreams int32
+		wantStatus    int
+	}{
+		{
+			name:          "ok when all assigned streams are active",
+			open:          true,
+			assignedVbIDs: 4,
+			activeStreams: 4,
+			wantStatus:    fiber.StatusOK,
+		},
+		{
+			name:          "unavailable when some streams are abandoned",
+			open:          true,
+			assignedVbIDs: 4,
+			activeStreams: 2,
+			wantStatus:    fiber.StatusServiceUnavailable,
+		},
+		{
+			// During rebalance the stream is closed (IsOpen()==false) for the
+			// whole close->reopen window, so the active-stream check is skipped
+			// and the in-flight teardown never reports a false negative.
+			name:          "ok during rebalance even with fewer active streams",
+			open:          false,
+			assignedVbIDs: 4,
+			activeStreams: 0,
+			wantStatus:    fiber.StatusOK,
+		},
+		{
+			name:          "error when couchbase ping fails",
+			pingErr:       errors.New("ping failed"),
+			open:          true,
+			assignedVbIDs: 4,
+			activeStreams: 4,
+			wantStatus:    fiber.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &api{
+				client: &fakeClient{pingErr: tc.pingErr},
+				stream: &fakeStream{
+					open:          tc.open,
+					assignedVbIDs: tc.assignedVbIDs,
+					activeStreams: tc.activeStreams,
+				},
+			}
+
+			app := fiber.New()
+			app.Get("/status", a.status)
+
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/status", nil))
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("got status %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -415,6 +415,7 @@ func (s *stream) wait() {
 func (s *stream) Close(closeWithCancel bool) {
 	vBuckets := s.client.GetNumVBuckets()
 
+	s.open = false
 	s.closeWithCancel = closeWithCancel
 
 	s.eventHandler.BeforeStreamStop()
@@ -445,7 +446,6 @@ func (s *stream) Close(closeWithCancel bool) {
 
 	logger.Log.Info("stream stopped")
 	s.eventHandler.AfterStreamStop()
-	s.open = false
 
 	if !s.streamFinishedWithEndEventCh {
 		s.finishStreamWithCloseCh <- struct{}{}


### PR DESCRIPTION
## Problem

`/status` only pings Couchbase, so a pod whose vBucket streams have silently died still reports healthy. Operators cannot wire a Kubernetes liveness probe to detect the abandoned-stream condition; per-vBucket lag grows until someone restarts the pod manually.

## Change

When the stream is open, compare the active stream count (`GetMetric()`) against the number of assigned vBuckets (`GetOffsets().Count()`, constant between Open/Close) and return **503** with `only N/M dcp streams are active` when streams are missing. This makes `/status` usable as a liveness probe that self-heals abandoned-stream conditions.

A second commit moves `s.open = false` to the beginning of `Close()`: previously, stream end events decremented `activeStreams` while `IsOpen()` was still true for the duration of `Close()`, so a probe hitting that window during a healthy rebalance could report a false 503. With the flag flipped first, the check is skipped for the whole close→reopen span.

Reopen retries do **not** decrement the counter, so transient recovery windows don't flap the endpoint. Complementary to #151: that PR prevents abandonment, this one makes any remaining wedge detectable and recoverable.

## Testing

`go build` / `go vet` clean, all unit tests pass.
